### PR TITLE
New Typhoeus Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following table show the available adapters and which features they support.
 | [Net::HTTP]             | v1 only |   ✔️   |   ✔️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [Net::HTTP::Persistent] | v1 only |   ✔️   |   ✔️   |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [Patron]                | v1 only |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✖️   |   ✖️   |
-| [Typhoeus]              | v1 only |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
+| [Typhoeus]              | v1 only |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [HTTP.rb]               |   ✖️    |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |
 | [httpx]                 |   ✖️    |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |
 
@@ -92,6 +92,6 @@ TBC
 [Net::HTTP]:              https://github.com/lostisland/faraday-net_http
 [Net::HTTP::Persistent]:  https://github.com/lostisland/faraday-net_http_persistent
 [Patron]:                 https://github.com/lostisland/faraday-patron
-[Typhoeus]:               https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/adapters/faraday.rb
+[Typhoeus]:               https://github.com/dleavitt/faraday-typhoeus
 [HTTP.rb]:                https://github.com/lostisland/faraday-http
 [httpx]:                  https://honeyryderchuck.gitlab.io/httpx/wiki/Faraday-Adapter

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following table show the available adapters and which features they support.
 | [Net::HTTP]             | v1 only |   ✔️   |   ✔️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [Net::HTTP::Persistent] | v1 only |   ✔️   |   ✔️   |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [Patron]                | v1 only |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✖️   |   ✖️   |
-| [Typhoeus]              | v1 only |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
+| [Typhoeus]              | v1 only |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [HTTP.rb]               |   ✖️    |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |
 | [httpx]                 |   ✖️    |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |
 


### PR DESCRIPTION
I've created a new Typhoeus adapter for Faraday here:
- https://github.com/dleavitt/faraday-typhoeus (happy to move it under the Faraday org if you'd prefer.)
- https://rubygems.org/gems/faraday-typhoeus

It ports the (seemingly unmaintained) adapter bundled with Typhoeus to work with Faraday 2. It also adds support for streaming. It's documented (mostly cribbed examples), the adapter specs pass, and I think in general it's pretty adequate?