### PR TITLE
Add xml_response gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ In addition to this curated list of middleware, we would like to specifically ca
 - [retry](https://github.com/lostisland/faraday-retry) - retry intermittent HTTP failures
 - [rashify](https://github.com/lostisland/faraday-rashify) - parse responses into a [Hashie::Mash::Rash](https://github.com/hashie/hashie)
 - [follow_redirects](https://github.com/tisba/faraday-follow-redirects) - follow HTTP 30X redirects
+- [decode_xml](https://github.com/soberstadt/faraday-decode_xml) - decode XML responses
 
 #### `faraday_middleware` gem
 


### PR DESCRIPTION
Hi, I extracted the xml response parsing middleware from faraday_middleware into a [faraday-decode_xml](https://github.com/soberstadt/faraday-decode_xml) gem. It would be sweet to have this added to the list!

After reading the explanation for Faraday 2, I'm totally behind a zero-dependency Faraday and hope this change has helped maintaining and updating Faraday! Thanks for building a great gem!