### PR TITLE
faraday-http support streaming response

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following table show the available adapters and which features they support.
 | [Net::HTTP::Persistent] | v1 only |   ✔️   |   ✔️   |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [Patron]                | v1 only |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✖️   |   ✖️   |
 | [Typhoeus]              | v1 only |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
-| [HTTP.rb]               |   ✖️     |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |
+| [HTTP.rb]               |   ✖️     |   ✔️   |   ✖️   |   ✔️   |   ✖️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |
 | [httpx]                 |   ✖️     |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |
 
 


### PR DESCRIPTION
Since release 2.0 faraday-http supports response streaming.