### PR TITLE
Update Net::HTTP::Persistent's support for streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following table show the available adapters and which features they support.
 | [Excon]                 | v1 only |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [HttpClient]            | v1 only |   ✔️   |   ✔️   |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |
 | [Net::HTTP]             |   ✔️     |   ✔️   |   ✔️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
-| [Net::HTTP::Persistent] | v1 only |   ✔️   |   ✔️   |   ✖️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
+| [Net::HTTP::Persistent] | v1 only |   ✔️   |   ✔️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [Patron]                | v1 only |   ✔️   |   ✖️   |   ✖️   |   ✖️   |   ✖️   |   ✔️   |   ✖️   |   ✖️   |
 | [Typhoeus]              | v1 only |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✔️   |   ✖️   |
 | [HTTP.rb]               |   ✖️     |   ✔️   |   ✖️   |   ✔️   |   ✖️   |   ✔️   |   ✖️   |   ✔️   |   ✔️   |


### PR DESCRIPTION
https://github.com/lostisland/faraday-net_http_persistent/pull/6 implemented streaming response support and it was release in 1.2.0 (see https://github.com/lostisland/faraday-net_http_persistent/releases/tag/v1.2.0)