### PR TITLE
Fix link to middleware documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following table show the available adapters and which features they support.
 
 ## Middleware
 
-Under the hood, Faraday uses a Rack-inspired middleware stack for making requests. Much of Faraday’s power is unlocked with custom middleware. Some middleware is included with Faraday, and others are in external gems. [Learn more about Middleware](https://lostisland.github.io/faraday/middleware/).
+Under the hood, Faraday uses a Rack-inspired middleware stack for making requests. Much of Faraday’s power is unlocked with custom middleware. Some middleware is included with Faraday, and others are in external gems. [Learn more about Middleware](https://lostisland.github.io/faraday/#/middleware/index).
 
 In addition to this curated list of middleware, we would like to specifically call your attention to middleware that is helpful for general HTTP use:
 


### PR DESCRIPTION
The link on 'Learn more about Middleware' is broken so I have updated it.